### PR TITLE
Feature/fix widget update

### DIFF
--- a/src/app/interfaces/graph.interface.ts
+++ b/src/app/interfaces/graph.interface.ts
@@ -2,7 +2,7 @@ import { BehaviorSubject } from 'rxjs';
 import { DataPoint } from '../models/data-point.model';
 
 export interface IGraph {
-  id?: number;
+  id?: number | null;
   type: string | undefined;
   query: string;
   interval: number;

--- a/src/app/models/graph.backend-model.ts
+++ b/src/app/models/graph.backend-model.ts
@@ -1,12 +1,12 @@
 export class GraphBackend {
-  GraphId: number;
+  GraphId: number | null;
   Type: string;
   Query: string;
   Interval: number;
   Color: string;
 
   constructor(
-    GraphId: number,
+    GraphId: number | null,
     Type: string,
     Query: string,
     Interval: number,

--- a/src/app/models/graph.model.ts
+++ b/src/app/models/graph.model.ts
@@ -4,7 +4,7 @@ import { IGraph } from '../interfaces/graph.interface';
 import { DataPoint } from './data-point.model';
 
 export class Graph implements IGraph {
-  id: number;
+  id: number | null;
   type: string;
   query: string;
   interval: number;
@@ -13,7 +13,7 @@ export class Graph implements IGraph {
   last: BehaviorSubject<DataPoint | null> = new BehaviorSubject<DataPoint | null>(null)
 
   constructor(
-    id: number,
+    id: number | null,
     type: string,
     query: string,
     interval: number,

--- a/src/app/pages/dashboard/form/form.component.html
+++ b/src/app/pages/dashboard/form/form.component.html
@@ -25,11 +25,11 @@
         </div>
         <h3>Graphs</h3>
         <hr />
-        <div *ngFor="let graph of widget.graphs">
+        <div *ngFor="let graph of widget.graphs; let i = index">
           <div class="mb-3">
             <label for="queries" class="form-label">Query Builder</label>
-            <textarea type="text" name="query" #query="ngModel" class="form-control"
-              [(ngModel)]="graph.query"></textarea>
+            <textarea type="text" name="widget.graphs[{{i}}].query" #query="ngModel" class="form-control"
+              [(ngModel)]="widget.graphs[i].query"></textarea>
           </div>
 
           <div class="mb-3">

--- a/src/app/pages/dashboard/form/form.component.html
+++ b/src/app/pages/dashboard/form/form.component.html
@@ -34,13 +34,13 @@
 
           <div class="mb-3">
             <label for="interval" class="form-label">Interval (in seconds)</label>
-            <input type="number" min=5 class="form-control form-control" value="" [(ngModel)]="graph.interval"
-              name="interval" #interval="ngModel">
+            <input type="number" min=5 class="form-control form-control" [(ngModel)]="widget.graphs[i].interval"
+              name="widgt.graphs[{{i}}]" #interval="ngModel">
           </div>
 
           <div class="mb-3">
             <label for="chartType" class="form-label">Type</label>
-            <select [(ngModel)]="graph.type" name="chartType" #Type="ngModel" class="form-control">
+            <select [(ngModel)]="widget.graphs[i].type" name="widget.graphs[{{i}}].type" #Type="ngModel" class="form-control">
               <option value="bar">Bar Chart</option>
               <option value="line">Line Chart</option>
               <option value="doughnut">Doughtnut Chart</option>
@@ -50,8 +50,8 @@
           </div>
           <div class="mb-3">
             <label for="color" class="form-label">Color</label>
-            <input type="color" class="form-control form-control-color" value="#563d7c" [(ngModel)]="graph.color"
-              name="color" #Color="ngModel">
+            <input type="color" class="form-control form-control-color" value="#563d7c" [(ngModel)]="widget.graphs[i].color"
+              name="widget.graphs[{{i}}].color" #Color="ngModel">
           </div>
           <hr>
         </div>

--- a/src/app/pages/dashboard/form/form.component.ts
+++ b/src/app/pages/dashboard/form/form.component.ts
@@ -107,7 +107,7 @@ export class FormComponent implements OnInit {
   }
 
   addQueryToForm() {
-    this.widget.graphs?.push(new Graph(0, "bar", "", 5, "#c81030"));
+    this.widget.graphs?.push(new Graph(null, "bar", "", 5, "#c81030"));
 
     console.log('New Query has been added');
   }


### PR DESCRIPTION
Deze PR zal het volgende fixen:

- Bij een update deden nieuwe queries de oude vervangen. Die gebeurt niet meer
- Wanneer je meerdere graphs had in een widget, werden de gegevens van de laatste graph in alle velden gezet van de Form. Dit is nu gefixed.
- Bij het toevoegen van een nieuwe graph werden de bestaande graph velden leeg gemaakt. Dit gebeurt niet meer.